### PR TITLE
Environment constructor and `GetTemplate`

### DIFF
--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -7,12 +7,12 @@ const VariableEndString = "}}"
 const CommentStartString = "{#"
 const CommentEndString = "#}"
 const TrimBlocks = false
-const LstripBlocks = false
+const LStripBlocks = false
 const NewlineSequence = "\n"
 const KeepTrailingNewline = false
 
 var LineStatementPrefix *string = nil
 var LineCommentPrefix *string = nil
 
-var DefaultNamespace = map[string]func(...any) any{}
+var DefaultNamespace = map[string]any{}
 var DefaultPolicies = map[string]any{}

--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -13,3 +13,6 @@ const KeepTrailingNewline = false
 
 var LineStatementPrefix *string = nil
 var LineCommentPrefix *string = nil
+
+var DefaultNamespace = map[string]func(...any) any{}
+var DefaultPolicies = map[string]any{}

--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -14,5 +14,16 @@ const KeepTrailingNewline = false
 var LineStatementPrefix *string = nil
 var LineCommentPrefix *string = nil
 
-var DefaultNamespace = map[string]any{}
-var DefaultPolicies = map[string]any{}
+var DefaultNamespace = map[string]any{
+	// TODO fill
+}
+var DefaultPolicies = map[string]any{
+	"compiler.ascii_str":   true,
+	"urlize.rel":           "noopener",
+	"urlize.target":        nil,
+	"urlize.extra_schemes": nil,
+	"truncate.leeway":      5,
+	"json.dumps_function":  nil,
+	"json.dumps_kwargs":    map[string]any{"sort_keys": true},
+	"ext.i18n.trimmed":     false,
+}

--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -29,7 +29,7 @@ type Environment struct {
 	TemplateClass Class
 	*lexer.EnvLexerInformation
 	Optimized  bool
-	Extensions map[string]Extension // extension name or extension
+	Extensions map[string]Extension
 	Undefined  UndefinedConstructor
 	Finalize   func(...any) any
 	AutoEscape func(name string) bool

--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -5,7 +5,6 @@ import (
 	"github.com/gojinja/gojinja/src/defaults"
 	"github.com/gojinja/gojinja/src/filters"
 	"github.com/gojinja/gojinja/src/lexer"
-	"github.com/gojinja/gojinja/src/loaders"
 	"github.com/gojinja/gojinja/src/runtime"
 	"github.com/gojinja/gojinja/src/tests"
 	"github.com/gojinja/gojinja/src/utils/maps"
@@ -34,7 +33,7 @@ type Environment struct {
 	Undefined  runtime.UndefinedClass
 	Finalize   func(...any) any
 	AutoEscape any // bool or func(string)bool
-	Loader     *loaders.Loader
+	Loader     *Loader
 	Cache      Cache
 	AutoReload bool
 	Filters    map[string]filters.Filter
@@ -130,7 +129,7 @@ type EnvOpts struct {
 	Undefined  runtime.UndefinedClass
 	Finalize   func(...any) any
 	AutoEscape any // bool or func(string)bool
-	Loader     *loaders.Loader
+	Loader     *Loader
 	CacheSize  int
 	AutoReload bool
 }

--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -30,7 +30,7 @@ type Environment struct {
 	*lexer.EnvLexerInformation
 	Optimized  bool
 	Extensions map[string]Extension // extension name or extension
-	Undefined  runtime.UndefinedClass
+	Undefined  UndefinedConstructor
 	Finalize   func(...any) any
 	AutoEscape any // bool or func(string)bool
 	Loader     *Loader
@@ -126,7 +126,7 @@ type EnvOpts struct {
 	*lexer.EnvLexerInformation
 	Optimized  bool
 	Extensions map[string]func(*Environment) Extension // TODO jinja accepts also extensions names but it's python import magic I don't know how to do it in golang.
-	Undefined  runtime.UndefinedClass
+	Undefined  UndefinedConstructor
 	Finalize   func(...any) any
 	AutoEscape any // bool or func(string)bool
 	Loader     *Loader
@@ -134,17 +134,21 @@ type EnvOpts struct {
 	AutoReload bool
 }
 
+type UndefinedConstructor func(hint *string, obj any, name *string, exc func(msg string) error) runtime.IUndefined
+
 func DefaultEnvOpts() *EnvOpts {
 	return &EnvOpts{
 		Optimized:           true,
 		Extensions:          nil,
 		EnvLexerInformation: lexer.DefaultEnvLexerInformation(),
-		Undefined:           runtime.UndefinedClass{},
-		Finalize:            nil,
-		AutoEscape:          false,
-		Loader:              nil,
-		CacheSize:           400,
-		AutoReload:          true,
+		Undefined: func(hint *string, obj any, name *string, exc func(msg string) error) runtime.IUndefined {
+			return runtime.NewUndefined(hint, obj, name, exc)
+		},
+		Finalize:   nil,
+		AutoEscape: false,
+		Loader:     nil,
+		CacheSize:  400,
+		AutoReload: true,
 	}
 }
 

--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -1,8 +1,150 @@
 package environment
 
-import "github.com/gojinja/gojinja/src/lexer"
+import (
+	"fmt"
+	"github.com/gojinja/gojinja/src/defaults"
+	"github.com/gojinja/gojinja/src/filters"
+	"github.com/gojinja/gojinja/src/lexer"
+	"github.com/gojinja/gojinja/src/loaders"
+	"github.com/gojinja/gojinja/src/runtime"
+	"github.com/gojinja/gojinja/src/tests"
+	"github.com/gojinja/gojinja/src/utils/maps"
+	"github.com/gojinja/gojinja/src/utils/slices"
+	lru "github.com/hashicorp/golang-lru"
+	"strings"
+)
 
+// Environment is the core component of Jinja.  It contains
+// important shared variables like configuration, filters, tests,
+// globals and others.  Instances of this class may be modified if
+// they are not shared and if no template was loaded so far.
+// Modifications on environments after the first template was loaded
+// will lead to surprising effects and undefined behavior.
 type Environment struct {
+	Sandboxed     bool
+	Overlayed     bool
+	LinkedTo      *Environment
+	Shared        bool
+	Concat        func([]string) string
+	ContextClass  runtime.ContextClass
 	TemplateClass Class
 	*lexer.EnvLexerInformation
+	Optimized  bool
+	Extensions map[string]Extension // extension name or extension
+	Undefined  runtime.UndefinedClass
+	Finalize   func(...any) any
+	AutoEscape any // bool or func(string)bool
+	Loader     *loaders.Loader
+	Cache      Cache
+	AutoReload bool
+	Filters    map[string]filters.Filter
+	Tests      map[string]tests.Test
+	Globals    map[string]func(...any) any
+	Policies   map[string]any
+}
+
+type Cache interface {
+	Add(key, value interface{}) (evicted bool)
+	Get(key interface{}) (value interface{}, ok bool)
+}
+
+type mapCache map[interface{}]interface{}
+
+func (m mapCache) Add(key, value interface{}) (evicted bool) {
+	m[key] = value
+	return false
+}
+func (m mapCache) Get(key interface{}) (value interface{}, ok bool) {
+	v, ok := m[key]
+	return v, ok
+}
+
+func New(opts *EnvOpts) (*Environment, error) {
+	var err error
+	env := &Environment{
+		Sandboxed:           false,
+		Overlayed:           false,
+		LinkedTo:            nil,
+		Shared:              false,
+		Concat:              func(strs []string) string { return strings.Join(strs, "") },
+		ContextClass:        runtime.ContextClass{},
+		TemplateClass:       Class{},
+		EnvLexerInformation: opts.EnvLexerInformation,
+		Optimized:           opts.Optimized,
+		Undefined:           opts.Undefined,
+		Finalize:            opts.Finalize,
+		AutoEscape:          opts.AutoEscape,
+		Loader:              opts.Loader,
+		AutoReload:          opts.AutoReload,
+		Filters:             maps.Copy(filters.Default),
+		Tests:               maps.Copy(tests.Default),
+		Globals:             maps.Copy(defaults.DefaultNamespace),
+		Policies:            maps.Copy(defaults.DefaultPolicies),
+	}
+	env.Cache, err = createCache(opts.CacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	env.Extensions = LoadExtensions(env, opts.Extensions)
+	if err = configCheck(env); err != nil {
+		return nil, err
+	}
+	return env, nil
+}
+
+func configCheck(env *Environment) error {
+	if env.BlockStartString == env.VariableStartString || env.BlockStartString == env.CommentStartString || env.CommentStartString == env.VariableStartString {
+		return fmt.Errorf("block, variable and comment start strings must be different")
+	}
+	if !slices.Contains([]string{"\n", "\r\n", "\r"}, env.NewlineSequence) {
+		return fmt.Errorf("'NewlineSequence' must be one of '\\n', '\\r\\n', or '\\r'")
+	}
+	return nil
+}
+
+func LoadExtensions(env *Environment, extensions map[string]func(*Environment) Extension) map[string]Extension {
+	ret := make(map[string]Extension)
+	for k, v := range extensions {
+		ret[k] = v(env)
+	}
+	return ret
+}
+
+func createCache(cacheSize int) (Cache, error) {
+	if cacheSize > 0 {
+		return lru.New(cacheSize)
+	}
+	if cacheSize < 0 {
+		return make(mapCache), nil
+	}
+	return nil, nil
+}
+
+type Extension struct{} // TODO change to real extension
+
+type EnvOpts struct {
+	*lexer.EnvLexerInformation
+	Optimized  bool
+	Extensions map[string]func(*Environment) Extension // TODO jinja accepts also extensions names but it's python import magic I don't know how to do it in golang.
+	Undefined  runtime.UndefinedClass
+	Finalize   func(...any) any
+	AutoEscape any // bool or func(string)bool
+	Loader     *loaders.Loader
+	CacheSize  int
+	AutoReload bool
+}
+
+func DefaultEnvOpts() *EnvOpts {
+	return &EnvOpts{
+		Optimized:           true,
+		Extensions:          nil,
+		EnvLexerInformation: lexer.DefaultEnvLexerInformation(),
+		Undefined:           runtime.UndefinedClass{},
+		Finalize:            nil,
+		AutoEscape:          false,
+		Loader:              nil,
+		CacheSize:           400,
+		AutoReload:          true,
+	}
 }

--- a/src/environment/environment.go
+++ b/src/environment/environment.go
@@ -80,6 +80,9 @@ func New(opts *EnvOpts) (*Environment, error) {
 		Policies:            maps.Copy(defaults.DefaultPolicies),
 	}
 	env.AutoEscape, err = convertAutoEscape(opts.AutoEscape)
+	if err != nil {
+		return nil, err
+	}
 
 	env.Cache, err = createCache(opts.CacheSize)
 	if err != nil {

--- a/src/environment/environment_test.go
+++ b/src/environment/environment_test.go
@@ -1,0 +1,7 @@
+package environment
+
+import "testing"
+
+func Test(t *testing.T) {
+	// Just to compile this module
+}

--- a/src/environment/loaders.go
+++ b/src/environment/loaders.go
@@ -1,8 +1,7 @@
-package loaders
+package environment
 
 import (
 	"github.com/gojinja/gojinja/src/encoding"
-	"github.com/gojinja/gojinja/src/environment"
 	"github.com/gojinja/gojinja/src/errors"
 	"github.com/gojinja/gojinja/src/utils"
 	"github.com/gojinja/gojinja/src/utils/maps"
@@ -30,11 +29,11 @@ type Loader struct {
 
 type LoaderEmbed interface {
 	HasSourceAccess() bool
-	GetSource(env *environment.Environment, template string) (string, *string, environment.UpToDate, error)
+	GetSource(env *Environment, template string) (string, *string, UpToDate, error)
 	ListTemplates() ([]string, error)
 }
 
-func (l *Loader) Load(env *environment.Environment, name string, globals map[string]any) (environment.ITemplate, error) {
+func (l *Loader) Load(env *Environment, name string, globals map[string]any) (ITemplate, error) {
 	source, filename, upToDate, err := l.GetSource(env, name)
 	if err != nil {
 		return nil, err
@@ -52,7 +51,7 @@ func (f fsLoader) HasSourceAccess() bool {
 	return true
 }
 
-func (f fsLoader) GetSource(_ *environment.Environment, template string) (string, *string, environment.UpToDate, error) {
+func (f fsLoader) GetSource(_ *Environment, template string) (string, *string, UpToDate, error) {
 	pieces, err := splitTemplatePath(template)
 	if err != nil {
 		return "", nil, nil, err

--- a/src/environment/template.go
+++ b/src/environment/template.go
@@ -4,10 +4,13 @@ type Class struct{}
 
 type Template struct{}
 
-type ITemplate interface{}
+type ITemplate interface {
+	IsUpToDate() bool
+	Globals() map[string]any
+}
 
 type UpToDate = func() bool
 
-func (Class) FromSource(env Environment, source string, filename *string, globals map[string]any, upToData UpToDate) (ITemplate, error) {
+func (Class) FromSource(env *Environment, source string, filename *string, globals map[string]any, upToData UpToDate) (ITemplate, error) {
 	panic("TODO implemented")
 }

--- a/src/filters/filters.go
+++ b/src/filters/filters.go
@@ -1,0 +1,5 @@
+package filters
+
+type Filter func(args []any, kwargs map[string]any) any
+
+var Default = map[string]Filter{}

--- a/src/filters/filters.go
+++ b/src/filters/filters.go
@@ -2,4 +2,6 @@ package filters
 
 type Filter func(args []any, kwargs map[string]any) any
 
-var Default = map[string]Filter{}
+var Default = map[string]Filter{
+	// TODO fill
+}

--- a/src/lexer/env.go
+++ b/src/lexer/env.go
@@ -28,7 +28,7 @@ func DefaultEnvLexerInformation() *EnvLexerInformation {
 		LineStatementPrefix: defaults.LineStatementPrefix,
 		LineCommentPrefix:   defaults.LineCommentPrefix,
 		TrimBlocks:          defaults.TrimBlocks,
-		LStripBlocks:        defaults.LstripBlocks,
+		LStripBlocks:        defaults.LStripBlocks,
 		NewlineSequence:     defaults.NewlineSequence,
 		KeepTrailingNewline: defaults.KeepTrailingNewline,
 	}

--- a/src/loaders/loaders.go
+++ b/src/loaders/loaders.go
@@ -30,11 +30,11 @@ type Loader struct {
 
 type LoaderEmbed interface {
 	HasSourceAccess() bool
-	GetSource(env environment.Environment, template string) (string, *string, environment.UpToDate, error)
+	GetSource(env *environment.Environment, template string) (string, *string, environment.UpToDate, error)
 	ListTemplates() ([]string, error)
 }
 
-func (l *Loader) Load(env environment.Environment, name string, globals map[string]any) (environment.ITemplate, error) {
+func (l *Loader) Load(env *environment.Environment, name string, globals map[string]any) (environment.ITemplate, error) {
 	source, filename, upToDate, err := l.GetSource(env, name)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func (f fsLoader) HasSourceAccess() bool {
 	return true
 }
 
-func (f fsLoader) GetSource(_ environment.Environment, template string) (string, *string, environment.UpToDate, error) {
+func (f fsLoader) GetSource(_ *environment.Environment, template string) (string, *string, environment.UpToDate, error) {
 	pieces, err := splitTemplatePath(template)
 	if err != nil {
 		return "", nil, nil, err

--- a/src/runtime/context.go
+++ b/src/runtime/context.go
@@ -1,0 +1,5 @@
+package runtime
+
+type Context struct{}
+
+type ContextClass struct{}

--- a/src/runtime/undefined.go
+++ b/src/runtime/undefined.go
@@ -2,4 +2,9 @@ package runtime
 
 type Undefined struct{}
 
-type UndefinedClass struct{}
+type IUndefined interface{}
+
+func NewUndefined(hint *string, obj any, name *string, exc func(msg string) error) Undefined {
+	// TODO
+	return Undefined{}
+}

--- a/src/runtime/undefined.go
+++ b/src/runtime/undefined.go
@@ -1,0 +1,5 @@
+package runtime
+
+type Undefined struct{}
+
+type UndefinedClass struct{}

--- a/src/tests/tests.go
+++ b/src/tests/tests.go
@@ -1,0 +1,5 @@
+package tests
+
+type Test func(...any) bool
+
+var Default = map[string]Test{}

--- a/src/tests/tests.go
+++ b/src/tests/tests.go
@@ -2,4 +2,6 @@ package tests
 
 type Test func(...any) bool
 
-var Default = map[string]Test{}
+var Default = map[string]Test{
+	// TODO fill
+}

--- a/src/utils/maps/maps.go
+++ b/src/utils/maps/maps.go
@@ -13,6 +13,14 @@ func Keys[K comparable, V any](m map[K]V) []K {
 	return keys
 }
 
+func Copy[K comparable, V any](m map[K]V) map[K]V {
+	res := make(map[K]V)
+	for k, v := range m {
+		res[k] = v
+	}
+	return res
+}
+
 func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
 	keys := Keys(m)
 	sort.Slice(keys, func(i int, j int) bool { return keys[i] < keys[j] })

--- a/src/utils/maps/maps.go
+++ b/src/utils/maps/maps.go
@@ -27,6 +27,25 @@ func SortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
 	return keys
 }
 
+func Chain[K comparable, V any](ms ...map[K]V) map[K]V {
+	res := make(map[K]V)
+	for _, m := range ms {
+		for k, v := range m {
+			if _, ok := res[k]; !ok {
+				res[k] = v
+			}
+		}
+	}
+	return res
+}
+
+func Update[K comparable, V any](m map[K]V, update map[K]V) map[K]V {
+	for k, v := range update {
+		m[k] = v
+	}
+	return m
+}
+
 func Values[K comparable, V any](m map[K]V) []V {
 	values := make([]V, 0, len(m))
 	for _, v := range m {


### PR DESCRIPTION
closes #7 
Moved `loaders` to `environement` package to avoid cyclic dep